### PR TITLE
Verify file is open, avoid infinite loop

### DIFF
--- a/src/Processor/LastResort.php
+++ b/src/Processor/LastResort.php
@@ -40,8 +40,16 @@ class LastResort implements ProcessorInterface
         $bytesCopied = 0;
         $fin = fopen($from, "rb");
         $fout = fopen($to, "w");
-        while (!feof($fin)) {
-            $bytesCopied += fwrite($fout, fread($fin, $bytesToRead));
+        while (false !== $fin && false !== $fout && !feof($fin)) {
+            $bytesRead = fread($fin, $bytesToRead);
+            if ($bytesRead === false) {
+                break;
+            }
+            $bytesWritten = fwrite($fout, $bytesRead);
+            if ($bytesWritten === false) {
+                break;
+            }
+            $bytesCopied += $bytesWritten;
         }
         fclose($fin);
         fclose($fout);


### PR DESCRIPTION
Ran into a situation on my local where `drush cron` took forever. Log was filled with:

`Warning: fread() expects parameter 1 to be resource, boolean given in FileFetcher\Processor\LastResort->copy() (line 44 of /var/www/docroot/vendor/getdkan/file-fetcher/src/Processor/LastResort.php)`

This PR attempts to address the infinite loop by checking the file handle returns a resource instead of `FALSE`.