### PR TITLE
Switch to a direct copy() for local files.

### DIFF
--- a/src/Processor/Local.php
+++ b/src/Processor/Local.php
@@ -2,12 +2,20 @@
 
 namespace FileFetcher\Processor;
 
-class Local extends AbstractChunkedProcessor
+use FileFetcher\PhpFunctionsBridgeTrait;
+use Procrastinator\Result;
+
+class Local implements ProcessorInterface
 {
 
-    protected function getFileSize(string $filePath): int
+    use PhpFunctionsBridgeTrait;
+
+    /**
+     * Local constructor.
+     */
+    public function __construct()
     {
-        return $this->php->filesize($filePath);
+        $this->initializePhpFunctionsBridge();
     }
 
     public function isServerCompatible(array $state): bool
@@ -21,13 +29,26 @@ class Local extends AbstractChunkedProcessor
         return false;
     }
 
-    protected function getChunk(string $filePath, int $start, int $end)
+    public function setupState(array $state): array
     {
-        $fp = fopen($filePath, 'r');
-        fseek($fp, $start);
-        $bytesToCopy = $end - $start;
-        $data = fread($fp, $bytesToCopy);
-        fclose($fp);
-        return $data;
+        $state['total_bytes'] = PHP_INT_MAX;
+        $state['total_bytes'] = $this->php->filesize($state['from']);
+
+        return $state;
+    }
+
+    public function isTimeLimitIncompatible(): bool
+    {
+        return true;
+    }
+
+    public function copy(array $state, Result $result, int $timeLimit = PHP_INT_MAX): array
+    {
+        $this->php->copy($state['from'], $state['to']);
+        print_r($state);
+        $state['total_bytes_copied'] = $this->php->filesize($state['to']);
+        $result->setStatus(Result::DONE);
+
+        return ['state' => $state, 'result' => $result];
     }
 }

--- a/src/Processor/Local.php
+++ b/src/Processor/Local.php
@@ -3,12 +3,14 @@
 namespace FileFetcher\Processor;
 
 use FileFetcher\PhpFunctionsBridgeTrait;
+use FileFetcher\TemporaryFilePathFromUrl;
 use Procrastinator\Result;
 
 class Local implements ProcessorInterface
 {
 
     use PhpFunctionsBridgeTrait;
+    use TemporaryFilePathFromUrl;
 
     /**
      * Local constructor.
@@ -32,7 +34,9 @@ class Local implements ProcessorInterface
     public function setupState(array $state): array
     {
         $state['total_bytes'] = PHP_INT_MAX;
-        $state['total_bytes'] = $this->php->filesize($state['from']);
+        $state['total_bytes'] = $this->php->filesize($state['source']);
+        $state['temporary'] = true;
+        $state['destination'] = $this->getTemporaryFilePath($state);
 
         return $state;
     }
@@ -44,9 +48,8 @@ class Local implements ProcessorInterface
 
     public function copy(array $state, Result $result, int $timeLimit = PHP_INT_MAX): array
     {
-        $this->php->copy($state['from'], $state['to']);
-        print_r($state);
-        $state['total_bytes_copied'] = $this->php->filesize($state['to']);
+        $this->php->copy($state['source'], $state['destination']);
+        $state['total_bytes_copied'] = $this->php->filesize($state['destination']);
         $result->setStatus(Result::DONE);
 
         return ['state' => $state, 'result' => $result];

--- a/test/FileFetcherTest.php
+++ b/test/FileFetcherTest.php
@@ -25,6 +25,9 @@ class FileFetcherTest extends TestCase
             ]
         );
 
+        // Local does not support time limits.
+        $this->assertFalse($fetcher->setTimeLimit(1));
+
         $fetcher->run();
 
         // [Basic Usage]

--- a/test/FileFetcherTest.php
+++ b/test/FileFetcherTest.php
@@ -38,8 +38,6 @@ class FileFetcherTest extends TestCase
             file_get_contents($state['source']),
             file_get_contents($state['destination'])
         );
-
-        unlink($state['destination']);
     }
 
     public function testKeepOriginalFilename()
@@ -61,8 +59,6 @@ class FileFetcherTest extends TestCase
             basename($state['source']),
             basename($state['destination'])
         );
-
-        unlink($state['destination']);
     }
 
     public function testConfigValidationErrorConfigurationMissing()

--- a/test/FileFetcherTest.php
+++ b/test/FileFetcherTest.php
@@ -25,9 +25,6 @@ class FileFetcherTest extends TestCase
             ]
         );
 
-        // How much time do we want to spend copying the file (In seconds).
-        $fetcher->setTimeLimit(1);
-
         $fetcher->run();
 
         // [Basic Usage]


### PR DESCRIPTION
The previous implementation was copying local files in batched chunks, loading all the content through PHP. This turned out to be very slow (even with moderately sized files) as well as fragile (if 2 copy requests came in at once the file would get corrupted with duplicate writes).

For now we are switching to a direct `copy()` which completes reasonably fast even for large files on most filesystems (1-5m for a 6.5GB file on Acquia, for example). If we later turn out to need to copy files 10s of GB we can switch to another technique (rsync would be a good choice for huge files) although there isn't any reason php-cli can't run indefinitely on a server, as long as it doesn't have increasing memory usage.

I updated the tests to stop removing the temporary files, since we no longer need temporary files here.
