### PR TITLE
Prevent Remote Processor from performing an HTTP request prematurely

### DIFF
--- a/src/Processor/Remote.php
+++ b/src/Processor/Remote.php
@@ -2,10 +2,9 @@
 
 namespace FileFetcher\Processor;
 
-use Procrastinator\Result;
-
 class Remote extends AbstractChunkedProcessor
 {
+    protected const HTTP_URL_REGEX = '^(?:(?:https?)://)?(?:\S+(?::\S*)?@|\d{1,3}(?:\.\d{1,3}){3}|(?:(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)(?:\.(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)*(?:\.[a-z\x{00a1}-\x{ffff}]{2,6}))(?::\d+)?(?:[^\s]*)?$';
 
     protected function getFileSize(string $filePath): int
     {
@@ -15,13 +14,7 @@ class Remote extends AbstractChunkedProcessor
 
     public function isServerCompatible(array $state): bool
     {
-        $headers = $this->getHeaders($state['source']);
-
-        if (isset($headers['Accept-Ranges']) && isset($headers['Content-Length'])) {
-            return true;
-        }
-
-        return false;
+        return preg_match(self::HTTP_URL_REGEX, $state['source']) !== 1;
     }
 
     protected function getChunk(string $filePath, int $start, int $end)
@@ -29,7 +22,6 @@ class Remote extends AbstractChunkedProcessor
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $filePath);
         curl_setopt($ch, CURLOPT_RANGE, "{$start}-{$end}");
-        curl_setopt($ch, CURLOPT_BINARYTRANSFER, 1);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         $result = $this->php->curl_exec($ch);
         curl_close($ch);

--- a/src/Processor/Remote.php
+++ b/src/Processor/Remote.php
@@ -4,7 +4,7 @@ namespace FileFetcher\Processor;
 
 class Remote extends AbstractChunkedProcessor
 {
-    protected const HTTP_URL_REGEX = '^(?:(?:https?)://)?(?:\S+(?::\S*)?@|\d{1,3}(?:\.\d{1,3}){3}|(?:(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)(?:\.(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)*(?:\.[a-z\x{00a1}-\x{ffff}]{2,6}))(?::\d+)?(?:[^\s]*)?$';
+    protected const HTTP_URL_REGEX = '%^(?:https?://)?(?:\S+(?::\S*)?@|\d{1,3}(?:\.\d{1,3}){3}|(?:(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)(?:\.(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)*(?:\.[a-z\x{00a1}-\x{ffff}]{2,6}))(?::\d+)?(?:[^\s]*)?$%iu';
 
     protected function getFileSize(string $filePath): int
     {
@@ -14,7 +14,7 @@ class Remote extends AbstractChunkedProcessor
 
     public function isServerCompatible(array $state): bool
     {
-        return preg_match(self::HTTP_URL_REGEX, $state['source']) !== 1;
+        return preg_match(self::HTTP_URL_REGEX, $state['source']) === 1;
     }
 
     protected function getChunk(string $filePath, int $start, int $end)

--- a/test/Processor/RemoteTest.php
+++ b/test/Processor/RemoteTest.php
@@ -63,25 +63,22 @@ class RemoteTest extends TestCase
         $this->assertTrue(true);
     }
 
-    public function testCurlHeaders()
+    /**
+     * Test the \FileFetcher\Processor\Remote::isServerCompatible() method.
+     */
+    public function testIsServerCompatible()
     {
-        $options = (new Options())
-        ->add('curl_exec', "Accept-Ranges:TRUE\nContent-Length:10")
-        ->index(0);
-
-        $bridge = (new Chain($this))
-        ->add(PhpFunctionsBridge::class, '__call', $options)
-        ->getMock();
-
         $processor = new Remote();
-        $processor->setPhpFunctionsBridge($bridge);
-        $this->assertTrue(
-            $processor->isServerCompatible([
-              'source' => 'hello',
-              'destination' => 'goodbye',
-              'total_bytes_copied' => 1,
-              'total_bytes' => 10,
-            ])
-        );
+
+        // Ensure isServerCompatible() succeeds when supplied valid sources.
+        $this->assertTrue($processor->isServerCompatible(['source' => 'example.org']));
+        $this->assertTrue($processor->isServerCompatible(['source' => 'http://example.org']));
+        $this->assertTrue($processor->isServerCompatible(['source' => 'https://example.org']));
+
+        // Ensure isServerCompatible() fails when supplied invalid sources.
+        $this->assertFalse($processor->isServerCompatible(['source' => 'invalid']));
+        $this->assertFalse($processor->isServerCompatible(['source' => 'http://invalid']));
+        $this->assertFalse($processor->isServerCompatible(['source' => 'https://invalid']));
+        $this->assertFalse($processor->isServerCompatible(['source' => 'ftp://example.org']));
     }
 }


### PR DESCRIPTION
This rather small PR changes the Remote Processor so that it performs a RegEx instead of an HTTP request against a source in order to determine whether it's a URL.