### PR TITLE
Set some methods to protected to allow overrides

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=7.4 <8.2",
         "ext-curl": "*",
-        "getdkan/procrastinator": "dev-abstractpersistentjob-protected",
+        "getdkan/procrastinator": "^4.0.2",
         "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=7.4 <8.2",
         "ext-curl": "*",
-        "getdkan/procrastinator": "^4.0.2",
+        "getdkan/procrastinator": "dev-abstractpersistentjob-protected",
         "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5"
     },
     "require-dev": {

--- a/src/FileFetcher.php
+++ b/src/FileFetcher.php
@@ -17,7 +17,7 @@ use Procrastinator\Job\AbstractPersistentJob;
 class FileFetcher extends AbstractPersistentJob
 {
 
-    protected array $customProcessorClasses = [];
+    private array $customProcessorClasses = [];
 
     /**
      * Constructor.
@@ -90,12 +90,12 @@ class FileFetcher extends AbstractPersistentJob
         return $processors;
     }
 
-    protected function getProcessor(): ProcessorInterface
+    private function getProcessor(): ProcessorInterface
     {
         return $this->getProcessors()[$this->getStateProperty('processor')];
     }
 
-    protected function validateConfig($config): array
+    private function validateConfig($config): array
     {
         if (!is_array($config)) {
             throw new \Exception("Constructor missing expected config filePath.");

--- a/src/FileFetcher.php
+++ b/src/FileFetcher.php
@@ -17,7 +17,7 @@ use Procrastinator\Job\AbstractPersistentJob;
 class FileFetcher extends AbstractPersistentJob
 {
 
-    private array $customProcessorClasses = [];
+    protected array $customProcessorClasses = [];
 
     /**
      * Constructor.

--- a/src/FileFetcher.php
+++ b/src/FileFetcher.php
@@ -90,7 +90,7 @@ class FileFetcher extends AbstractPersistentJob
         return $processors;
     }
 
-    private function getProcessor(): ProcessorInterface
+    protected function getProcessor(): ProcessorInterface
     {
         return $this->getProcessors()[$this->getStateProperty('processor')];
     }

--- a/src/FileFetcher.php
+++ b/src/FileFetcher.php
@@ -71,7 +71,7 @@ class FileFetcher extends AbstractPersistentJob
         return $info['result'];
     }
 
-    private function getProcessors()
+    protected function getProcessors(): array
     {
         $processors = self::getDefaultProcessors();
         foreach ($this->customProcessorClasses as $processorClass) {
@@ -95,7 +95,7 @@ class FileFetcher extends AbstractPersistentJob
         return $this->getProcessors()[$this->getStateProperty('processor')];
     }
 
-    private function validateConfig($config): array
+    protected function validateConfig($config): array
     {
         if (!is_array($config)) {
             throw new \Exception("Constructor missing expected config filePath.");
@@ -109,7 +109,7 @@ class FileFetcher extends AbstractPersistentJob
         return $config;
     }
 
-    private function setProcessors($config)
+    protected function setProcessors($config)
     {
         if (!isset($config['processors'])) {
             return;


### PR DESCRIPTION
This PR only changes some of `FileFetcher\FileFetcher`'s members to be `protected` instead of `private`.
This is to support changes in https://github.com/GetDKAN/dkan/pull/4035