### PR TITLE
Handle file wrapper errors in Local

### DIFF
--- a/src/Processor/Local.php
+++ b/src/Processor/Local.php
@@ -10,10 +10,13 @@ class Local extends ProcessorBase implements ProcessorInterface
     {
         $path = $state['source'];
 
-        if (file_exists($path) && !is_dir($path)) {
-            return true;
+        try {
+            if (file_exists($path) && !is_dir($path)) {
+                return true;
+            }
+        } catch (\Throwable $t) {
+            // If there was an error, then the local file is not available.
         }
-
         return false;
     }
 

--- a/src/Processor/ProcessorInterface.php
+++ b/src/Processor/ProcessorInterface.php
@@ -22,9 +22,20 @@ use Procrastinator\Result;
 interface ProcessorInterface
 {
     /**
-     * Whether the server holding the "file" will work with this processor.
+     * Whether the state for this file transfer will work with this processor.
+     *
+     * For instance, a Local processor will check if the source file exists. A
+     * Remote processor will check if the source URL is valid.
+     *
+     * This method is called to determine which configured processor to use to
+     * perform the fetch.
+     *
+     * @param array $state
+     *   The file fetcher object's state array.
      *
      * @return bool
+     *   True if the processor can be used with the state/configuration. False
+     *   otherwise.
      */
     public function isServerCompatible(array $state): bool;
 

--- a/test/Processor/LocalTest.php
+++ b/test/Processor/LocalTest.php
@@ -2,17 +2,32 @@
 
 namespace FileFetcherTests\Processor;
 
-use FileFetcher\PhpFunctionsBridge;
 use FileFetcher\Processor\Local;
-use MockChain\Chain;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \FileFetcher\Processor\Local
+ * @coversDefaultClass \FileFetcher\Processor\Local
+ */
 class LocalTest extends TestCase
 {
-    public function test()
+
+    public function provideSource()
+    {
+        return [
+            'any-normal-file' => ['blah'],
+            'no-such-wrapper' => ['s3://foo.bar'],
+        ];
+    }
+
+    /**
+     * @covers ::isServerCompatible
+     * @dataProvider provideSource
+     */
+    public function test($source)
     {
         $processor = new Local();
-        $state = ['source' => 'blah'];
+        $state = ['source' => $source];
         $this->assertFalse(
             $processor->isServerCompatible($state)
         );


### PR DESCRIPTION
We were seeing a situation where URIs with a scheme of `s3://` was showing up in `Local`. These would throw an error like this:
```
file_exists(): Unable to find the wrapper "s3" - did you forget to enable it when you configured PHP?
```
This is because `Local::isServerCompatible()` is calling `file_exists()` as part of determining whether the processor is appropriate. Clearly it's not...

This PR wraps the `file_exists()` and nearby logic in a `try` block, in order to return false if there was an error.