### PR TITLE
Ensure processors are determined at runtime

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" verbose="false">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+    colors="true"
+>
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">src</directory>
@@ -7,7 +11,7 @@
   </coverage>
   <testsuites>
     <testsuite name="all">
-      <directory suffix="Test.php" phpVersion="7.2" phpVersionOperator="&gt;=">test</directory>
+      <directory phpVersion="7.4" phpVersionOperator=">=">test</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/src/FileFetcher.php
+++ b/src/FileFetcher.php
@@ -29,7 +29,7 @@ class FileFetcher extends AbstractPersistentJob
      *
      * Stored here so that we don't have to recompute it.
      *
-     * @var \FileFetcher\Processor\ProcessorInterface
+     * @var \FileFetcher\Processor\ProcessorInterface|null
      */
     private ?ProcessorInterface $processor = null;
 
@@ -69,7 +69,7 @@ class FileFetcher extends AbstractPersistentJob
      */
     protected function __construct(string $identifier, $storage, array $config = null)
     {
-        parent::__construct($identifier, $storage, $config);
+        parent::__construct($identifier, $storage);
 
         $this->setProcessors($config);
 
@@ -111,10 +111,10 @@ class FileFetcher extends AbstractPersistentJob
     }
 
     /**
-     * Gets the combined default and custom processors list.
+     * Gets the combined custom and default processors list.
      *
      * @return array
-     *   The combined default and custom processors list, prioritizing the
+     *   The combined custom and default processors list, prioritizing the
      *   custom ones in the order they were defined.
      */
     protected function getProcessors(): array
@@ -215,7 +215,7 @@ class FileFetcher extends AbstractPersistentJob
         }
         if ($config_processors = $config['processors'] ?? false) {
             $this->processor = null;
-            // Unset the configured processors from custmProcessorClasses.
+            // Unset the configured processors from customProcessorClasses.
             foreach ($config_processors as $config_processor) {
                 // Use array_keys() with its search parameter.
                 foreach (array_keys($this->customProcessorClasses, $config_processor) as $existing) {

--- a/src/FileFetcher.php
+++ b/src/FileFetcher.php
@@ -216,17 +216,29 @@ class FileFetcher extends AbstractPersistentJob
         if ($config_processors = $config['processors'] ?? false) {
             $this->processor = null;
             // Unset the configured processors from customProcessorClasses.
-            foreach ($config_processors as $config_processor) {
-                // Use array_keys() with its search parameter.
-                foreach (array_keys($this->customProcessorClasses, $config_processor) as $existing) {
-                    unset($this->customProcessorClasses[$existing]);
-                }
-            }
+            $this->unsetDuplicateCustomProcessorClasses($config_processors);
             // Merge in the configuration.
             $this->customProcessorClasses = array_merge(
                 $config_processors,
                 $this->customProcessorClasses
             );
+        }
+    }
+
+    /**
+     * Unset items in $this->customProcessorClasses present in the given array.
+     *
+     * @param array $processors
+     *   Processor class names to be removed from the list of custom processor
+     *   classes.
+     */
+    private function unsetDuplicateCustomProcessorClasses(array $processors):void
+    {
+        foreach ($processors as $processor) {
+            // Use array_keys() with its search parameter.
+            foreach (array_keys($this->customProcessorClasses, $processor) as $existing) {
+                unset($this->customProcessorClasses[$existing]);
+            }
         }
     }
 

--- a/src/Processor/Local.php
+++ b/src/Processor/Local.php
@@ -8,7 +8,7 @@ class Local extends ProcessorBase implements ProcessorInterface
 {
     public function isServerCompatible(array $state): bool
     {
-        $path = $state['source'];
+        $path = $state['source'] ?? '';
 
         if (file_exists($path) && !is_dir($path)) {
             return true;

--- a/src/Processor/Remote.php
+++ b/src/Processor/Remote.php
@@ -13,7 +13,8 @@ class Remote extends ProcessorBase implements ProcessorInterface
 
     public function isServerCompatible(array $state): bool
     {
-        return preg_match(self::HTTP_URL_REGEX, $state['source']) === 1;
+        $source = $state['source'] ?? '';
+        return preg_match(self::HTTP_URL_REGEX, $source) === 1;
     }
 
     public function setupState(array $state): array

--- a/test/FileFetcherTest.php
+++ b/test/FileFetcherTest.php
@@ -251,5 +251,4 @@ class FileFetcherTest extends TestCase
             FakeRemote::class,
         ], $ref_custom_processors->getValue($fetcher));
     }
-
 }

--- a/test/FileFetcherTest.php
+++ b/test/FileFetcherTest.php
@@ -5,6 +5,7 @@ namespace FileFetcherTests;
 use Contracts\Mock\Storage\Memory;
 use FileFetcher\FileFetcher;
 use FileFetcher\Processor\Local;
+use FileFetcherTests\Mock\FakeLocal;
 use PHPUnit\Framework\TestCase;
 
 class FileFetcherTest extends TestCase
@@ -107,5 +108,61 @@ class FileFetcherTest extends TestCase
         );
         // Not sure what to assert.
         $this->assertTrue(true);
+    }
+
+    public function testSwitchProcessor()
+    {
+        $file_path = __DIR__ . '/files/tiny.csv';
+        $temporary_directory = '/temp/foo';
+        // Storage.
+        $storage = new Memory();
+        // Empty.
+        $this->assertCount(0, $storage->retrieveAll());
+
+        // Create a file fetcher. Its state will be stored in the memory
+        // storage. Specify a non-standard temp dir so that we can test it.
+        $config = [
+            'filePath' => $file_path,
+            'temporaryDirectory' => $temporary_directory
+        ];
+        $fetcher = FileFetcher::get('1', $storage, $config);
+        // Did the ff get stored?
+        $this->assertCount(1, $storage->retrieveAll());
+        // Ensure we stored the path and temp dir.
+        $this->assertEquals($file_path, $fetcher->getState()['source']);
+        $this->assertEquals($temporary_directory, $fetcher->getState()['temporary_directory']);
+
+        // Ensure there's no processor info in the state.
+        $this->assertArrayNotHasKey('processor', $fetcher->getState());
+        $this->assertArrayNotHasKey('customProcessorClasses', $fetcher->getState());
+
+        // What is the processor object?
+        $ref_get_processor = new \ReflectionMethod(
+            FileFetcher::class,
+            'getProcessor'
+        );
+        $ref_get_processor->setAccessible(true);
+        $this->assertInstanceOf(
+            Local::class,
+            $ref_get_processor->invoke($fetcher)
+        );
+
+        // Retrieve the fetcher again, with config for a different processor.
+        $fetcher = null;
+        $config = [
+            'filePath' => $file_path,
+            'processors' => [FakeLocal::class]
+        ];
+        $fetcher = FileFetcher::get('1', $storage, $config);
+
+        // The temporary directory should be our non-default one, proving that
+        // it was retrieved from storage.
+        $this->assertEquals($temporary_directory, $fetcher->getState()['temporary_directory']);
+
+        // Processor should be the one we specified in ::get().
+        $this->assertInstanceOf(
+            FakeLocal::class,
+            $ref_get_processor->invoke($fetcher)
+        );
     }
 }

--- a/test/FileFetcherTest.php
+++ b/test/FileFetcherTest.php
@@ -76,7 +76,6 @@ class FileFetcherTest extends TestCase
 
     public function testCustomProcessorsValidationIsNotAnArray()
     {
-        $this->markTestIncomplete('why do we need the thing this tests?');
         $fetcher = FileFetcher::get(
             "2",
             new Memory(),
@@ -140,12 +139,8 @@ class FileFetcherTest extends TestCase
         $this->assertEquals($file_path, $fetcher->getState()['source']);
         $this->assertEquals($temporary_directory, $fetcher->getState()['temporary_directory']);
 
-        // Ensure there's no processor info in the state.
-        $this->assertArrayNotHasKey('processor', $fetcher->getState());
-        $this->assertArrayNotHasKey('customProcessorClasses', $fetcher->getState());
-
         // What is the processor object?
-        $ref_get_processor = new \ReflectionMethod($fetcher, 'getProcessor');
+        $ref_get_processor = new \ReflectionMethod(FileFetcher::class, 'getProcessor');
         $ref_get_processor->setAccessible(true);
         $this->assertInstanceOf(
             Local::class,
@@ -172,18 +167,10 @@ class FileFetcherTest extends TestCase
 
         // Retrieve the fetcher again, this time with a different custom
         // processor.
-        $fetcher = null;
         $fetcher = FileFetcher::get('1', $storage, [
             'filePath' => $file_path,
             'processors' => [FakeProcessor::class]
         ]);
-        // Assert our non-standard temp directory again.
-        $this->assertEquals($temporary_directory, $fetcher->getState()['temporary_directory']);
-        // Processor should be the one we specified in configuration.
-        $this->assertInstanceOf(
-            FakeProcessor::class,
-            $ref_get_processor->invoke($fetcher)
-        );
         // The list of custom processors should include both custom processors
         // we specified.
         $ref_custom_processors = new \ReflectionProperty($fetcher, 'customProcessorClasses');
@@ -191,6 +178,14 @@ class FileFetcherTest extends TestCase
         $custom_processors = $ref_custom_processors->getValue($fetcher);
         $this->assertContains(FakeProcessor::class, $custom_processors);
         $this->assertContains(FakeLocal::class, $custom_processors);
+
+        // Assert our non-standard temp directory again.
+        $this->assertEquals($temporary_directory, $fetcher->getState()['temporary_directory']);
+        // Processor should be the one we specified in configuration.
+        $this->assertInstanceOf(
+            FakeProcessor::class,
+            $ref_get_processor->invoke($fetcher)
+        );
     }
 
     /**

--- a/test/FileFetcherTest.php
+++ b/test/FileFetcherTest.php
@@ -10,6 +10,10 @@ use FileFetcherTests\Mock\FakeProcessor;
 use FileFetcherTests\Mock\FakeRemote;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \FileFetcher\FileFetcher
+ * @coversDefaultClass \FileFetcher\FileFetcher
+ */
 class FileFetcherTest extends TestCase
 {
 
@@ -72,6 +76,7 @@ class FileFetcherTest extends TestCase
 
     public function testCustomProcessorsValidationIsNotAnArray()
     {
+        $this->markTestIncomplete('why do we need the thing this tests?');
         $fetcher = FileFetcher::get(
             "2",
             new Memory(),
@@ -112,7 +117,8 @@ class FileFetcherTest extends TestCase
         $this->assertTrue(true);
     }
 
-    public function testSwitchProcessor() {
+    public function testSwitchProcessor()
+    {
         $file_path = __DIR__ . '/files/tiny.csv';
         $temporary_directory = '/temp/foo';
         // Storage.
@@ -139,18 +145,15 @@ class FileFetcherTest extends TestCase
         $this->assertArrayNotHasKey('customProcessorClasses', $fetcher->getState());
 
         // What is the processor object?
-        $ref_get_processor = new \ReflectionMethod(
-            FileFetcher::class,
-            'getProcessor'
-        );
-        $ref_get_processor->setAccessible(TRUE);
+        $ref_get_processor = new \ReflectionMethod($fetcher, 'getProcessor');
+        $ref_get_processor->setAccessible(true);
         $this->assertInstanceOf(
             Local::class,
             $ref_get_processor->invoke($fetcher)
         );
 
         // Retrieve the fetcher again, with config for a different processor.
-        $fetcher = NULL;
+        $fetcher = null;
         $config = [
             'filePath' => $file_path,
             'processors' => [FakeLocal::class]
@@ -174,7 +177,7 @@ class FileFetcherTest extends TestCase
             'filePath' => $file_path,
             'processors' => [FakeProcessor::class]
         ]);
-        // Assert our non-standard temp directory.
+        // Assert our non-standard temp directory again.
         $this->assertEquals($temporary_directory, $fetcher->getState()['temporary_directory']);
         // Processor should be the one we specified in configuration.
         $this->assertInstanceOf(
@@ -188,6 +191,70 @@ class FileFetcherTest extends TestCase
         $custom_processors = $ref_custom_processors->getValue($fetcher);
         $this->assertContains(FakeProcessor::class, $custom_processors);
         $this->assertContains(FakeLocal::class, $custom_processors);
+    }
+
+    /**
+     * @covers ::addProcessors
+     */
+    public function testAddProcessors()
+    {
+        $file_path = __DIR__ . '/files/tiny.csv';
+        $temporary_directory = '/temp/foo';
+        // Storage.
+        $storage = new Memory();
+        // Empty.
+        $this->assertCount(0, $storage->retrieveAll());
+
+        // Get a file fetcher.
+        $fetcher = FileFetcher::get('1', $storage, [
+            'filePath' => $file_path,
+            'temporaryDirectory' => $temporary_directory
+        ]);
+
+        // Contains no custom processors.
+        $ref_custom_processors = new \ReflectionProperty($fetcher, 'customProcessorClasses');
+        $ref_custom_processors->setAccessible(true);
+        $this->assertEmpty($ref_custom_processors->getValue($fetcher));
+
+        // Let's add a custom processor.
+        $ref_add_processors = new \ReflectionMethod($fetcher, 'addProcessors');
+        $ref_add_processors->setAccessible(true);
+        $ref_add_processors->invokeArgs($fetcher, [[
+            'processors' => [
+                FakeProcessor::class,
+            ]
+        ]]);
+        // Our processor is in the custom processor list.
+        $this->assertEquals([
+            FakeProcessor::class,
+        ], $ref_custom_processors->getValue($fetcher));
+
+        // We can keep doing this. Add more and make sure they're in the correct
+        // order in the list of custom processors.
+        $ref_add_processors->invokeArgs($fetcher, [[
+            'processors' => [
+                FakeLocal::class,
+                FakeRemote::class,
+            ]
+        ]]);
+        // New processors are added to the top of the list.
+        $this->assertEquals([
+            FakeLocal::class,
+            FakeRemote::class,
+            FakeProcessor::class,
+        ], $ref_custom_processors->getValue($fetcher));
+
+        // Re-add FakeProcessor and its position should change in the list.
+        $ref_add_processors->invokeArgs($fetcher, [[
+            'processors' => [
+                FakeProcessor::class,
+            ]
+        ]]);
+        $this->assertEquals([
+            FakeProcessor::class,
+            FakeLocal::class,
+            FakeRemote::class,
+        ], $ref_custom_processors->getValue($fetcher));
     }
 
 }

--- a/test/Mock/FakeLocal.php
+++ b/test/Mock/FakeLocal.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace FileFetcherTests\Mock;
+
+use FileFetcher\Processor\Local;
+
+class FakeLocal extends Local
+{
+    public function isServerCompatible(array $state): bool
+    {
+        return true;
+    }
+}

--- a/test/Mock/FakeProcessor.php
+++ b/test/Mock/FakeProcessor.php
@@ -27,5 +27,4 @@ class FakeProcessor implements ProcessorInterface
     {
         return false;
     }
-
 }

--- a/test/Mock/FakeProcessor.php
+++ b/test/Mock/FakeProcessor.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace FileFetcherTests\Mock;
+
+use FileFetcher\Processor\Local;
+
+class FakeProcessor extends Local
+{
+    public function isServerCompatible(array $state): bool
+    {
+        return true;
+    }
+}

--- a/test/Mock/FakeProcessor.php
+++ b/test/Mock/FakeProcessor.php
@@ -3,11 +3,29 @@
 namespace FileFetcherTests\Mock;
 
 use FileFetcher\Processor\Local;
+use FileFetcher\Processor\ProcessorInterface;
+use Procrastinator\Result;
 
-class FakeProcessor extends Local
+class FakeProcessor implements ProcessorInterface
 {
     public function isServerCompatible(array $state): bool
     {
         return true;
     }
+
+    public function setupState(array $state): array
+    {
+        return $state;
+    }
+
+    public function copy(array $state, Result $result, int $timeLimit = PHP_INT_MAX): array
+    {
+        return ['state' => $state, 'result' => $result];
+    }
+
+    public function isTimeLimitIncompatible(): bool
+    {
+        return false;
+    }
+
 }


### PR DESCRIPTION
`FileFetcher` has allowed for configuration passed in to constructors to specify which file processors are used.

However, this is overridden by the fact that `FileFetcher` objects can be rehydrated from job stores, which ends up ignoring the processor config passed in. This can cause problems because different areas of DKAN might construct file fetchers with different configurations.

Furthermore, different runtimes of DKAN can require different processors, so we have to account for that as well.

Changes we make here:
- Override `FileFetcher::get()` in order to apply the runtime config after the object is rehydrated.
- Move processor determination to the point at which the processor is requested (in `getProcessor()`) so it can be modified at runtime.
- Adds `addProcessors()`, which is analogous to `setProcessors()` except it preserves the existing custom processor list.
- Adds tests to prove this all works.
- Many docblock improvements.