### PR TITLE
Support PHP 8.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
             tag: << parameters.version >>
         parameters:
             version:
-                default: "7.4"
+                default: "8.3"
                 description: The `cimg/php` Docker image version tag.
                 type: string
             install-flags:
@@ -154,7 +154,7 @@ jobs:
             - when:
                   condition:
                       and:
-                          - equal: [ "8.1", <<parameters.version>> ]
+                          - equal: [ "8.3", <<parameters.version>> ]
                           - equal: [ "", <<parameters.install-flags>> ]
                   steps:
                       - run-phpunit-tests:
@@ -164,7 +164,7 @@ jobs:
                   condition:
                       not:
                           and:
-                              - equal: [ "8.1", <<parameters.version>> ]
+                              - equal: [ "8.3", <<parameters.version>> ]
                               - equal: [ "", <<parameters.install-flags>> ]
                   steps:
                       - run-phpunit-tests:
@@ -176,5 +176,5 @@ workflows:
             - matrix-conditions:
                   matrix:
                       parameters:
-                          version: ["7.4", "8.0", "8.1", "8.2"]
+                          version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
                           install-flags: ["", "--prefer-lowest"]

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         }
     ],
     "require": {
-        "php": ">=7.4 <8.3",
+        "php": ">=7.4 <8.4",
         "ext-curl": "*",
-        "getdkan/procrastinator": "^5.0.0",
+        "getdkan/procrastinator": "dev-php83",
         "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=7.4 <8.4",
         "ext-curl": "*",
-        "getdkan/procrastinator": "dev-php83",
+        "getdkan/procrastinator": "^5.0.2",
         "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5"
     },
     "require-dev": {

--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\ValueObject\PhpVersion;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
@@ -18,11 +17,8 @@ return static function (RectorConfig $rectorConfig): void {
         __DIR__ . '/test',
     ]);
 
-    // Our base version of PHP.
-    $rectorConfig->phpVersion(PhpVersion::PHP_74);
-
     $rectorConfig->sets([
-        SetList::PHP_82,
+        SetList::PHP_74,
         // Please no dead code or unneeded variables.
         SetList::DEAD_CODE,
         // Try to figure out type hints.
@@ -41,6 +37,7 @@ return static function (RectorConfig $rectorConfig): void {
         AddMethodCallBasedStrictParamTypeRector::class,
     ]);
 
+    $rectorConfig->removeUnusedImports();
     $rectorConfig->importNames();
     $rectorConfig->importShortClasses(false);
 };

--- a/src/Processor/ProcessorBase.php
+++ b/src/Processor/ProcessorBase.php
@@ -2,10 +2,6 @@
 
 namespace FileFetcher\Processor;
 
-use FileFetcher\PhpFunctionsBridgeTrait;
-use FileFetcher\TemporaryFilePathFromUrl;
-use Procrastinator\Result;
-
 abstract class ProcessorBase
 {
     /**

--- a/test/Mock/FakeProcessor.php
+++ b/test/Mock/FakeProcessor.php
@@ -2,7 +2,6 @@
 
 namespace FileFetcherTests\Mock;
 
-use FileFetcher\Processor\Local;
 use FileFetcher\Processor\ProcessorInterface;
 use Procrastinator\Result;
 


### PR DESCRIPTION
- Adds PHP 8.3 to the testing matrix.
- Updates Composer dependencies to use PHP 8.3 compatible version of procrastinator.
- Updates Rector config to remove unused imports.