### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,5 +176,5 @@ workflows:
             - matrix-conditions:
                   matrix:
                       parameters:
-                          version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
+                          version: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
                           install-flags: ["", "--prefer-lowest"]

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "getdkan/contracts": "^1.2",
         "getdkan/mock-chain": "^1.3.6",
         "mikey179/vfsstream": "^1.6.11",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^9.6.22",
         "rector/rector": "^1@stable",
         "squizlabs/php_codesniffer": "^3.7",
         "symfony/phpunit-bridge": "^7.0"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4 <8.4",
+        "php": ">=7.4 <8.5",
         "ext-curl": "*",
         "getdkan/procrastinator": "^5.0.3",
         "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=7.4 <8.5",
         "ext-curl": "*",
         "getdkan/procrastinator": "^5.0.3",
-        "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5"
+        "guzzlehttp/guzzle": "^7.4.5"
     },
     "require-dev": {
         "getdkan/contracts": "^1.2",

--- a/src/FileFetcher.php
+++ b/src/FileFetcher.php
@@ -39,7 +39,7 @@ class FileFetcher extends AbstractPersistentJob
      * We override ::get() because it can set values for both newly constructed
      * objects and re-hydrated ones.
      */
-    public static function get(string $identifier, $storage, array $config = null)
+    public static function get(string $identifier, $storage, ?array $config = null)
     {
         $ff = parent::get($identifier, $storage, $config);
         // If we see that a processor is configured, we need to handle some
@@ -67,7 +67,7 @@ class FileFetcher extends AbstractPersistentJob
      *
      * @see static::get()
      */
-    protected function __construct(string $identifier, $storage, array $config = null)
+    protected function __construct(string $identifier, $storage, ?array $config = null)
     {
         parent::__construct($identifier, $storage);
 


### PR DESCRIPTION
Adds PHP 8.4 compatibility. Note guzzle 6.x no longer supported. This should not be an issue for DKAN, as 7.x is the requirement for Drupal 10. Still, this should probably be a minor release.