### PR TITLE
#44 Make runit defensive before calling setupState

### DIFF
--- a/src/FileFetcher.php
+++ b/src/FileFetcher.php
@@ -112,7 +112,7 @@ class FileFetcher extends AbstractPersistentJob
             return $info['result'];
         }
 
-        throw new \Exception("Processor is null, expected a processor. ");
+        throw new \Exception("No processor could be found to handle {$this->config['filePath']}.");
     }
 
     /**

--- a/src/FileFetcher.php
+++ b/src/FileFetcher.php
@@ -109,8 +109,10 @@ class FileFetcher extends AbstractPersistentJob
             $this->getResult()->setData(json_encode($state));
             $info = $processor->copy($this->getState(), $this->getResult(), $this->getTimeLimit());
             $this->setState($info['state']);
+            return $info['result'];
         }
-        return $info['result'] ?? NULL;
+
+        throw new \Exception("Processor is null, expected a processor. ");
     }
 
     /**

--- a/src/FileFetcher.php
+++ b/src/FileFetcher.php
@@ -103,11 +103,14 @@ class FileFetcher extends AbstractPersistentJob
      */
     protected function runIt()
     {
-        $state = $this->getProcessor()->setupState($this->getState());
-        $this->getResult()->setData(json_encode($state));
-        $info = $this->getProcessor()->copy($this->getState(), $this->getResult(), $this->getTimeLimit());
-        $this->setState($info['state']);
-        return $info['result'];
+        $processor = $this->getProcessor();
+        if ($processor) {
+            $state = $processor->setupState($this->getState());
+            $this->getResult()->setData(json_encode($state));
+            $info = $processor->copy($this->getState(), $this->getResult(), $this->getTimeLimit());
+            $this->setState($info['state']);
+        }
+        return $info['result'] ?? NULL;
     }
 
     /**


### PR DESCRIPTION
This should prevent the issue described in #44

The problem is I don't know how to reproduce this error.  It only happens on PDC when we start out with a dataset that has a downloadURL then loses it mid-stream. (resulting from the data dictionary injection fiasco) There is no way to intentionally save a dataset in that state because validation will not allow it to get that far.